### PR TITLE
Better error handling

### DIFF
--- a/lzfse-sys/Cargo.toml
+++ b/lzfse-sys/Cargo.toml
@@ -12,6 +12,7 @@ Crate to build the LZFSE reference implementation for lzfse-rs.
 """
 links = "lzfse"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "lzfse_sys"
@@ -21,4 +22,4 @@ path = "lib.rs"
 libc = "0.2"
 
 [build-dependencies]
-cc = "1.0"
+cc = "1"

--- a/lzfse-sys/build.rs
+++ b/lzfse-sys/build.rs
@@ -1,5 +1,3 @@
-extern crate cc;
-
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -18,7 +16,7 @@ fn main() {
         .file("lzfse/src/lzvn_decode_base.c")
         .file("lzfse/src/lzfse_fse.c")
         .out_dir(dst.join("lib"))
-        .compile("libbz2.a");
+        .compile("liblzfse.a");
 
     let src = env::current_dir().unwrap().join("lzfse").join("src");
     let include = dst.join("include");

--- a/lzfse-sys/lib.rs
+++ b/lzfse-sys/lib.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use libc::{c_char, c_void, size_t};
 
 extern "C" {

--- a/lzfse/Cargo.toml
+++ b/lzfse/Cargo.toml
@@ -10,10 +10,11 @@ categories = ["compression", "api-bindings"]
 description = """
 Rust bindings for the LZFSE reference implementation.
 """
+edition = "2018"
 
 [dependencies]
 libc = "0.2"
 lzfse-sys = { version = "1.0.0", path = "../lzfse-sys" }
 
 [dev-dependencies]
-rand = "0.7.3"
+rand = "0.7"

--- a/lzfse/src/lib.rs
+++ b/lzfse/src/lib.rs
@@ -32,10 +32,9 @@
 //! assert_eq!(input[..], uncompressed[..bytes_in]);
 //! ````
 
-extern crate libc;
-extern crate lzfse_sys as ffi;
-
 use libc::size_t;
+use lzfse_sys as ffi;
+use std::ptr;
 
 /// This type represents all possible errors that can occur when decompressing data.
 #[derive(PartialEq, Debug)]
@@ -54,7 +53,7 @@ pub fn encode_buffer(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
             output.len() as size_t,
             input.as_ptr() as *const _,
             input.len() as size_t,
-            0 as *mut _,
+            ptr::null_mut(),
         ) as usize
     };
 
@@ -73,7 +72,7 @@ pub fn decode_buffer(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
             output.len() as size_t,
             input.as_ptr() as *const _,
             input.len() as size_t,
-            0 as *mut _,
+            ptr::null_mut(),
         ) as usize
     };
 
@@ -86,8 +85,6 @@ pub fn decode_buffer(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
 
 #[cfg(test)]
 mod tests {
-    extern crate rand;
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR improves the error handling of the `decode_buffer` function.

It also updates the crate to the 2018 edition and fixes a few clippy warnings.